### PR TITLE
Add Fircles API controllers/services

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,10 +1,36 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthController } from './auth/auth.controller';
+import { AuthService } from './auth/auth.service';
+import { UserController } from './users/users.controller';
+import { UsersService } from './users/users.service';
+import { FircleController } from './fircles/fircles.controller';
+import { FirclesService } from './fircles/fircles.service';
+import { ItemController } from './items/items.controller';
+import { ItemsService } from './items/items.service';
+import { AuctionController } from './auctions/auctions.controller';
+import { AuctionsService } from './auctions/auctions.service';
+import { PrismaService } from './prisma.service';
 
 @Module({
   imports: [],
-  controllers: [AppController],
-  providers: [AppService],
+  controllers: [
+    AppController,
+    AuthController,
+    UserController,
+    FircleController,
+    ItemController,
+    AuctionController,
+  ],
+  providers: [
+    AppService,
+    AuthService,
+    UsersService,
+    FirclesService,
+    ItemsService,
+    AuctionsService,
+    PrismaService,
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/auctions/auctions.controller.ts
+++ b/apps/api/src/auctions/auctions.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Param, Post } from '@nestjs/common';
+import { AuctionsService } from './auctions.service';
+
+@Controller('auctions')
+export class AuctionController {
+  constructor(private readonly auctionsService: AuctionsService) {}
+
+  @Post('start')
+  start(@Body() body: any) {
+    return this.auctionsService.startAuction(body);
+  }
+
+  @Post(':id/bid')
+  bid(
+    @Param('id') id: string,
+    @Body('bidderId') bidderId: number,
+    @Body('amount') amount: number,
+  ) {
+    return this.auctionsService.bid(Number(id), Number(bidderId), Number(amount));
+  }
+
+  @Post(':id/close')
+  close(@Param('id') id: string) {
+    return this.auctionsService.closeAuction(Number(id));
+  }
+}

--- a/apps/api/src/auctions/auctions.service.ts
+++ b/apps/api/src/auctions/auctions.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class AuctionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  startAuction(data: any) {
+    return this.prisma.auction.create({ data });
+  }
+
+  bid(auctionId: number, bidderId: number, amount: number) {
+    return this.prisma.bid.create({
+      data: { auctionId, bidderId, amount },
+    });
+  }
+
+  async closeAuction(id: number) {
+    const bids = await this.prisma.bid.findMany({
+      where: { auctionId: id },
+      orderBy: { amount: 'desc' },
+      take: 1,
+    });
+    const winningBid = bids[0];
+    return this.prisma.auction.update({
+      where: { id },
+      data: { winningBidId: winningBid?.id },
+    });
+  }
+}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('google')
+  loginGoogle(@Body('token') token: string) {
+    return this.authService.oidcLogin('google', token);
+  }
+
+  @Post('microsoft')
+  loginMicrosoft(@Body('token') token: string) {
+    return this.authService.oidcLogin('microsoft', token);
+  }
+}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthService {
+  // Placeholder login logic
+  async oidcLogin(provider: 'google' | 'microsoft', token: string) {
+    // Here you would verify the token with the provider and fetch user info
+    return { provider, token };
+  }
+}

--- a/apps/api/src/fircles/fircles.controller.ts
+++ b/apps/api/src/fircles/fircles.controller.ts
@@ -1,0 +1,32 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { FirclesService } from './fircles.service';
+
+@Controller('fircles')
+export class FircleController {
+  constructor(private readonly firclesService: FirclesService) {}
+
+  @Post()
+  create(@Body() body: any) {
+    return this.firclesService.createFircle(body);
+  }
+
+  @Post(':id/invite')
+  invite(@Param('id') id: string, @Body('email') email: string) {
+    return this.firclesService.inviteMember(Number(id), email);
+  }
+
+  @Post(':id/accept')
+  accept(@Param('id') id: string, @Body('userId') userId: number) {
+    return this.firclesService.acceptInvite(Number(id), Number(userId));
+  }
+
+  @Get(':id/members')
+  members(@Param('id') id: string) {
+    return this.firclesService.getMembers(Number(id));
+  }
+
+  @Patch(':id/rules')
+  updateRules(@Param('id') id: string, @Body('rules') rules: string) {
+    return this.firclesService.updateRules(Number(id), rules);
+  }
+}

--- a/apps/api/src/fircles/fircles.service.ts
+++ b/apps/api/src/fircles/fircles.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class FirclesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  createFircle(data: any) {
+    return this.prisma.fircle.create({ data });
+  }
+
+  async inviteMember(fircleId: number, email: string) {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user) throw new Error('User not found');
+    return this.prisma.fircle.update({
+      where: { id: fircleId },
+      data: { members: { connect: { id: user.id } } },
+    });
+  }
+
+  acceptInvite(fircleId: number, userId: number) {
+    return this.prisma.fircle.update({
+      where: { id: fircleId },
+      data: { members: { connect: { id: userId } } },
+    });
+  }
+
+  getMembers(fircleId: number) {
+    return this.prisma.fircle.findUnique({
+      where: { id: fircleId },
+      select: { members: true },
+    });
+  }
+
+  updateRules(fircleId: number, rules: string) {
+    return this.prisma.fircle.update({
+      where: { id: fircleId },
+      data: { rules },
+    });
+  }
+}

--- a/apps/api/src/items/items.controller.ts
+++ b/apps/api/src/items/items.controller.ts
@@ -1,0 +1,45 @@
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
+import { ItemsService } from './items.service';
+
+@Controller('items')
+export class ItemController {
+  constructor(private readonly itemsService: ItemsService) {}
+
+  @Post()
+  add(@Body() body: any) {
+    return this.itemsService.addItem(body);
+  }
+
+  @Patch(':id')
+  edit(@Param('id') id: string, @Body() body: any) {
+    return this.itemsService.editItem(Number(id), body);
+  }
+
+  @Get('/fircle/:id')
+  list(@Param('id') id: string) {
+    return this.itemsService.listInFircle(Number(id));
+  }
+
+  @Post(':id/request-lend')
+  requestLend(
+    @Param('id') id: string,
+    @Body('requestedBy') requestedBy: number,
+    @Body('offerType') offerType: string,
+  ) {
+    return this.itemsService.requestLending(
+      Number(id),
+      Number(requestedBy),
+      offerType,
+    );
+  }
+
+  @Post(':id/sub-lend')
+  subLend(@Param('id') id: string, @Body('userId') userId: number) {
+    return this.itemsService.subLend(Number(id), Number(userId));
+  }
+
+  @Get(':id/ownership')
+  ownership(@Param('id') id: string) {
+    return this.itemsService.ownershipChain(Number(id));
+  }
+}

--- a/apps/api/src/items/items.service.ts
+++ b/apps/api/src/items/items.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class ItemsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  addItem(data: any) {
+    return this.prisma.item.create({ data });
+  }
+
+  editItem(id: number, data: any) {
+    return this.prisma.item.update({ where: { id }, data });
+  }
+
+  listInFircle(fircleId: number) {
+    return this.prisma.item.findMany({
+      where: {
+        owner: { memberOf: { some: { id: fircleId } } },
+      },
+    });
+  }
+
+  requestLending(itemId: number, requestedById: number, offerType: string) {
+    return this.prisma.lendingRequest.create({
+      data: { itemId, requestedById, offerType: offerType as any },
+    });
+  }
+
+  async subLend(itemId: number, newHolderId: number) {
+    const item = await this.prisma.item.update({
+      where: { id: itemId },
+      data: { currentHolderId: newHolderId },
+    });
+    return item;
+  }
+
+  async ownershipChain(itemId: number) {
+    const item = await this.prisma.item.findUnique({
+      where: { id: itemId },
+      select: { ownershipHistory: true },
+    });
+    return item?.ownershipHistory || [];
+  }
+}

--- a/apps/api/src/prisma.service.ts
+++ b/apps/api/src/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UserController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get(':id')
+  getUser(@Param('id') id: string) {
+    return this.usersService.getProfile(Number(id));
+  }
+
+  @Patch(':id')
+  updateUser(@Param('id') id: string, @Body() body: any) {
+    return this.usersService.updateProfile(Number(id), body);
+  }
+}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  getProfile(userId: number) {
+    return this.prisma.user.findUnique({ where: { id: userId } });
+  }
+
+  updateProfile(userId: number, data: any) {
+    return this.prisma.user.update({ where: { id: userId }, data });
+  }
+}


### PR DESCRIPTION
## Summary
- add PrismaService for DB access
- add auth, user, fircle, item and auction services
- wire up REST controllers for all endpoints
- register new providers/controllers in AppModule

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684314df022c832ebd6c1ce2daba189a