### PR TITLE
Add JWT auth and membership middleware

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,12 @@
     "@prisma/client": "^5.2.0",
     "@sendgrid/mail": "^7.7.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "passport": "^0.6.0",
+    "passport-jwt": "^4.0.1",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,10 +1,16 @@
 import { Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma.service';
 
 @Injectable()
 export class AuthService {
-  // Placeholder login logic
+  constructor(private jwtService: JwtService, private prisma: PrismaService) {}
+
   async oidcLogin(provider: 'google' | 'microsoft', token: string) {
-    // Here you would verify the token with the provider and fetch user info
-    return { provider, token };
+    // In a real implementation you would verify the token with the provider
+    const user = await this.prisma.user.findFirst({ where: { oidcSub: token } });
+    if (!user) throw new Error('User not found');
+    const accessToken = await this.jwtService.signAsync({ sub: user.id });
+    return { provider, accessToken };
   }
 }

--- a/apps/api/src/middleware/auth.middleware.ts
+++ b/apps/api/src/middleware/auth.middleware.ts
@@ -1,0 +1,25 @@
+import { Injectable, NestMiddleware, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class AuthMiddleware implements NestMiddleware {
+  constructor(private jwtService: JwtService, private prisma: PrismaService) {}
+
+  async use(req: any, res: any, next: () => void) {
+    const header = req.headers['authorization'];
+    if (!header || !header.startsWith('Bearer ')) {
+      throw new UnauthorizedException('No token provided');
+    }
+    const token = header.split(' ')[1];
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      const user = await this.prisma.user.findUnique({ where: { id: payload.sub } });
+      if (!user) throw new UnauthorizedException('Invalid token');
+      req.user = user;
+      next();
+    } catch (err) {
+      throw new UnauthorizedException('Invalid token');
+    }
+  }
+}

--- a/apps/api/src/middleware/fircle-role.middleware.ts
+++ b/apps/api/src/middleware/fircle-role.middleware.ts
@@ -1,0 +1,33 @@
+import { Injectable, NestMiddleware, ForbiddenException } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+
+@Injectable()
+export class FircleRoleMiddleware implements NestMiddleware {
+  constructor(private prisma: PrismaService) {}
+
+  async use(req: any, res: any, next: () => void) {
+    const user = req.user;
+    const fircleId = Number(req.params.id || req.body.fircleId);
+    if (!fircleId) {
+      throw new ForbiddenException('Fircle id required');
+    }
+
+    const fircle = await this.prisma.fircle.findUnique({
+      where: { id: fircleId },
+      select: {
+        ownerId: true,
+        admins: { select: { id: true } },
+        members: { select: { id: true } },
+      },
+    });
+    if (!fircle) throw new ForbiddenException('Fircle not found');
+
+    const isOwner = fircle.ownerId === user.id;
+    const isAdmin = fircle.admins.some(a => a.id === user.id);
+    const isMember = fircle.members.some(m => m.id === user.id);
+    if (!isOwner && !isAdmin && !isMember) {
+      throw new ForbiddenException('Access to fircle denied');
+    }
+    next();
+  }
+}

--- a/apps/api/src/middleware/fircle-rules.middleware.ts
+++ b/apps/api/src/middleware/fircle-rules.middleware.ts
@@ -1,0 +1,15 @@
+import { Injectable, NestMiddleware, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class FircleRulesAcceptedMiddleware implements NestMiddleware {
+  async use(req: any, res: any, next: () => void) {
+    const user = req.user;
+    const fircleId = Number(req.params.id || req.body.fircleId);
+    const accepted = Array.isArray(user?.acceptedFircleRules) &&
+      user.acceptedFircleRules.includes(fircleId);
+    if (!accepted) {
+      throw new ForbiddenException('Fircle rules not accepted');
+    }
+    next();
+  }
+}

--- a/apps/api/src/middleware/gtc.middleware.ts
+++ b/apps/api/src/middleware/gtc.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class GtcAcceptedMiddleware implements NestMiddleware {
+  async use(req: any, res: any, next: () => void) {
+    const user = req.user;
+    if (!user?.acceptedGTC) {
+      throw new ForbiddenException('GTC not accepted');
+    }
+    next();
+  }
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -7,4 +7,6 @@ export interface Item {
 export interface User {
   id: number;
   name: string;
+  acceptedGTC?: boolean;
+  acceptedFircleRules?: number[];
 }


### PR DESCRIPTION
## Summary
- enable JWT in the API and sign tokens on OIDC login
- implement authentication and permission middleware
- expose fields for GTC and fircle rule acceptance

## Testing
- `npm test --silent` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843191160f4832e806acbd954d31de7