### PR TITLE
Add GTC acceptance flow

### DIFF
--- a/GTC.md
+++ b/GTC.md
@@ -1,0 +1,3 @@
+# General Terms and Conditions
+
+Welcome to Fircles. By using this service you agree to the following terms and conditions. This is a sample document used for demonstration purposes.

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -32,6 +32,8 @@ model User {
   email          String    @unique
   profilePicture String?
   acceptedGTC    Boolean   @default(false)
+  gtcVersion     String?
+  gtcAcceptedAt  DateTime?
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,6 +13,7 @@ import { ItemsService } from './items/items.service';
 import { AuctionController } from './auctions/auctions.controller';
 import { AuctionsService } from './auctions/auctions.service';
 import { NotificationsController } from './notifications/notifications.controller';
+import { GtcController } from './gtc/gtc.controller';
 import { NotificationsService } from './notifications/notifications.service';
 import { PrismaService } from './prisma.service';
 import { AuthMiddleware } from './middleware/auth.middleware';
@@ -35,6 +36,7 @@ import { FircleRulesAcceptedMiddleware } from './middleware/fircle-rules.middlew
     ItemController,
     AuctionController,
     NotificationsController,
+    GtcController,
   ],
   providers: [
     AppService,
@@ -53,7 +55,11 @@ import { FircleRulesAcceptedMiddleware } from './middleware/fircle-rules.middlew
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
-    consumer.apply(AuthMiddleware, GtcAcceptedMiddleware).forRoutes('*');
+    consumer.apply(AuthMiddleware).forRoutes('*');
+    consumer
+      .apply(GtcAcceptedMiddleware)
+      .exclude('gtc', { path: 'users/:id/accept-gtc', method: RequestMethod.POST })
+      .forRoutes('*');
 
     consumer
       .apply(FircleRoleMiddleware, FircleRulesAcceptedMiddleware)

--- a/apps/api/src/gtc/gtc.controller.ts
+++ b/apps/api/src/gtc/gtc.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { GTC_VERSION } from './version';
+
+@Controller('gtc')
+export class GtcController {
+  private docPath = join(__dirname, '../../../GTC.md');
+
+  @Get()
+  getDocument() {
+    const content = readFileSync(this.docPath, 'utf8');
+    return { version: GTC_VERSION, content };
+  }
+}

--- a/apps/api/src/gtc/version.ts
+++ b/apps/api/src/gtc/version.ts
@@ -1,0 +1,1 @@
+export const GTC_VERSION = '1.0';

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,5 +1,6 @@
-import { Body, Controller, Get, Param, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { GTC_VERSION } from '../gtc/version';
 
 @Controller('users')
 export class UserController {
@@ -13,5 +14,10 @@ export class UserController {
   @Patch(':id')
   updateUser(@Param('id') id: string, @Body() body: any) {
     return this.usersService.updateProfile(Number(id), body);
+  }
+
+  @Post(':id/accept-gtc')
+  acceptGtc(@Param('id') id: string) {
+    return this.usersService.acceptGtc(Number(id), GTC_VERSION);
   }
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -12,4 +12,15 @@ export class UsersService {
   updateProfile(userId: number, data: any) {
     return this.prisma.user.update({ where: { id: userId }, data });
   }
+
+  acceptGtc(userId: number, version: string) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        acceptedGTC: true,
+        gtcVersion: version,
+        gtcAcceptedAt: new Date(),
+      },
+    });
+  }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
     "next": "14.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.3.0"
+    "zustand": "^4.3.0",
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/apps/web/pages/gtc.tsx
+++ b/apps/web/pages/gtc.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import ReactMarkdown from 'react-markdown';
+
+interface Doc {
+  version: string;
+  content: string;
+}
+
+export default function GtcPage() {
+  const [doc, setDoc] = useState<Doc | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch('/api/gtc')
+      .then((res) => res.json())
+      .then(setDoc)
+      .catch(() => {});
+  }, []);
+
+  const accept = async () => {
+    await fetch('/api/users/1/accept-gtc', { method: 'POST' });
+    router.push('/dashboard');
+  };
+
+  if (!doc) return <main className="p-4">Loading...</main>;
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Terms and Conditions</h1>
+      <ReactMarkdown className="prose">{doc.content}</ReactMarkdown>
+      <button className="px-4 py-2 bg-blue-500 text-white" onClick={accept}>
+        Accept
+      </button>
+    </main>
+  );
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -8,5 +8,7 @@ export interface User {
   id: number;
   name: string;
   acceptedGTC?: boolean;
+  gtcVersion?: string;
+  gtcAcceptedAt?: string;
   acceptedFircleRules?: number[];
 }


### PR DESCRIPTION
## Summary
- add mandatory GTC document and expose via API
- track GTC version and acceptance time in users
- add endpoint for accepting GTC
- exclude GTC routes from acceptance middleware
- add frontend page to display and accept GTC
- include `react-markdown` dependency

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431a06dbd4832e83b7ed2311b95a4f