### PR TITLE
Add lending service

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -45,6 +45,8 @@ model User {
   itemsHeld    Item[]   @relation("ItemHolder")
   bids         Bid[]
   requests     LendingRequest[] @relation("Requestor")
+  ownershipChangesFrom OwnershipChange[] @relation("OwnershipChangesFrom")
+  ownershipChangesTo   OwnershipChange[] @relation("OwnershipChangesTo")
 }
 
 model Fircle {
@@ -84,6 +86,7 @@ model Item {
   lendingRequests LendingRequest[]
   auctions        Auction[]
   bids            Bid[]
+  ownershipChanges OwnershipChange[]
 }
 
 model LendingRequest {
@@ -129,5 +132,17 @@ model Notification {
   message   String
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
+}
+
+model OwnershipChange {
+  id              Int      @id @default(autoincrement())
+  itemId          Int
+  item            Item     @relation(fields: [itemId], references: [id])
+  fromUserId      Int?
+  fromUser        User?    @relation("OwnershipChangesFrom", fields: [fromUserId], references: [id])
+  toUserId        Int
+  toUser          User     @relation("OwnershipChangesTo", fields: [toUserId], references: [id])
+  profitPercentage Float?
+  createdAt       DateTime @default(now())
 }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { AuctionsService } from './auctions/auctions.service';
 import { NotificationsController } from './notifications/notifications.controller';
 import { GtcController } from './gtc/gtc.controller';
 import { NotificationsService } from './notifications/notifications.service';
+import { LendingService } from './lending/lending.service';
 import { PrismaService } from './prisma.service';
 import { AuthMiddleware } from './middleware/auth.middleware';
 import { GtcAcceptedMiddleware } from './middleware/gtc.middleware';
@@ -46,6 +47,7 @@ import { FircleRulesAcceptedMiddleware } from './middleware/fircle-rules.middlew
     ItemsService,
     AuctionsService,
     PrismaService,
+    LendingService,
     NotificationsService,
     AuthMiddleware,
     GtcAcceptedMiddleware,

--- a/apps/api/src/lending/lending.service.ts
+++ b/apps/api/src/lending/lending.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { RequestStatus } from '@prisma/client';
+
+@Injectable()
+export class LendingService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  requestLend(itemId: number, requestedById: number, offerType: string) {
+    return this.prisma.lendingRequest.create({
+      data: { itemId, requestedById, offerType: offerType as any },
+    });
+  }
+
+  async respondToRequest(requestId: number, accept: boolean) {
+    const request = await this.prisma.lendingRequest.findUnique({
+      where: { id: requestId },
+    });
+    if (!request) throw new Error('Request not found');
+
+    if (!accept) {
+      return this.prisma.lendingRequest.update({
+        where: { id: requestId },
+        data: { status: RequestStatus.REJECTED },
+      });
+    }
+
+    await this.transferItem(request.itemId, request.requestedById);
+    return this.prisma.lendingRequest.update({
+      where: { id: requestId },
+      data: { status: RequestStatus.ACCEPTED },
+    });
+  }
+
+  async transferItem(itemId: number, newHolderId: number) {
+    const item = await this.prisma.item.findUnique({ where: { id: itemId } });
+    if (!item) throw new Error('Item not found');
+
+    const now = new Date();
+    const history: any[] = (item.ownershipHistory as any[]) || [];
+    const previousEntry = history.length ? history[history.length - 1] : null;
+
+    if (previousEntry && !previousEntry.end) {
+      previousEntry.end = now;
+      if (item.profitPercentage && item.price) {
+        previousEntry.profit =
+          item.price * (item.profitPercentage / 100);
+      }
+    }
+
+    history.push({ userId: newHolderId, start: now });
+
+    await this.prisma.ownershipChange.create({
+      data: {
+        itemId: item.id,
+        fromUserId: item.currentHolderId || item.ownerId,
+        toUserId: newHolderId,
+        profitPercentage: item.profitPercentage,
+      },
+    });
+
+    return this.prisma.item.update({
+      where: { id: item.id },
+      data: {
+        currentHolderId: newHolderId,
+        ownershipHistory: history,
+      },
+    });
+  }
+
+  ownershipLog(itemId: number) {
+    return this.prisma.ownershipChange.findMany({
+      where: { itemId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with OwnershipChange model
- create LendingService for handling lending requests and transfers
- log ownership changes and update item history
- register LendingService in the API module

## Testing
- `npm run build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431aeee9fc832eb8fb739570971287