### PR TITLE
Add abandoned fircle scheduler

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -9,16 +9,17 @@
   "dependencies": {
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
-    "@nestjs/platform-express": "^10.0.0",
-    "@prisma/client": "^5.2.0",
-    "@sendgrid/mail": "^7.7.0",
-    "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.1",
     "@nestjs/jwt": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/schedule": "^6.0.0",
+    "@prisma/client": "^5.2.0",
+    "@sendgrid/mail": "^7.7.0",
+    "jsonwebtoken": "^9.0.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",
-    "jsonwebtoken": "^9.0.0"
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -11,6 +11,7 @@ enum FircleState {
   ACTIVE
   INACTIVE
   ARCHIVED
+  ABANDONED
 }
 
 enum OfferType {
@@ -57,6 +58,8 @@ model Fircle {
   externalRef String?
   rules       String?
   state       FircleState @default(ACTIVE)
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
 
   ownerId Int
   owner   User   @relation("OwnedFircles", fields: [ownerId], references: [id])

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule, RequestMethod } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthController } from './auth/auth.controller';
@@ -16,6 +17,7 @@ import { NotificationsController } from './notifications/notifications.controlle
 import { GtcController } from './gtc/gtc.controller';
 import { NotificationsService } from './notifications/notifications.service';
 import { LendingService } from './lending/lending.service';
+import { MaintenanceService } from './maintenance/maintenance.service';
 import { PrismaService } from './prisma.service';
 import { AuthMiddleware } from './middleware/auth.middleware';
 import { GtcAcceptedMiddleware } from './middleware/gtc.middleware';
@@ -28,6 +30,7 @@ import { FircleRulesAcceptedMiddleware } from './middleware/fircle-rules.middlew
       secret: 'change-me',
       signOptions: { expiresIn: '1h' },
     }),
+    ScheduleModule.forRoot(),
   ],
   controllers: [
     AppController,
@@ -49,6 +52,7 @@ import { FircleRulesAcceptedMiddleware } from './middleware/fircle-rules.middlew
     PrismaService,
     LendingService,
     NotificationsService,
+    MaintenanceService,
     AuthMiddleware,
     GtcAcceptedMiddleware,
     FircleRoleMiddleware,

--- a/apps/api/src/maintenance/maintenance.service.ts
+++ b/apps/api/src/maintenance/maintenance.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PrismaService } from '../prisma.service';
+import { AuctionsService } from '../auctions/auctions.service';
+import { FircleState } from '@prisma/client';
+
+@Injectable()
+export class MaintenanceService {
+  private readonly logger = new Logger(MaintenanceService.name);
+  private readonly inactiveDays = Number(process.env.FIRCLE_INACTIVE_DAYS ?? 30);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auctionsService: AuctionsService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY)
+  async handleAbandonedFircles() {
+    const cutoff = new Date(Date.now() - this.inactiveDays * 24 * 60 * 60 * 1000);
+    const fircles = await this.prisma.fircle.findMany({
+      where: {
+        state: FircleState.ACTIVE,
+        updatedAt: { lt: cutoff },
+        owner: { updatedAt: { lt: cutoff } },
+      },
+      select: { id: true },
+    });
+
+    for (const f of fircles) {
+      await this.prisma.fircle.update({
+        where: { id: f.id },
+        data: { state: FircleState.ABANDONED },
+      });
+      await this.auctionsService.startAuction({ fircleId: f.id });
+      this.logger.log(`Fircle ${f.id} marked abandoned and auction started`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `@nestjs/schedule` dependency for API
- extend `FircleState` enum and model fields
- implement daily scheduler to mark abandoned fircles
- wire scheduler into `AppModule`

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431c1745c8832ea539717cc4e75501